### PR TITLE
Fix getCreatureSize to actually return the modified creature size

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -21,6 +21,7 @@
 		<includefile source="strings/strings_size_change.xml" />
 		<!-- Scripts -->
 		<script name="SizeChangeData" file="scripts/size_change_data.lua" />
+		<script name="SizeManager" file="scripts/manager_size.lua" />
 
 		<script name="SizeChangeAttack" file="scripts/size_change_attack.lua" />
 		<script name="SizeChangeDamage" file="scripts/size_change_damage.lua" />

--- a/scripts/manager_size.lua
+++ b/scripts/manager_size.lua
@@ -1,0 +1,13 @@
+getOriginalCreatureSize = nil
+
+function getCreatureSize(rActor)
+    local originalSize = getOriginalCreatureSize(rActor)
+    local sizeChange = EffectManager35E.getEffectsBonus(rActor, "SIZE", true, {"melee", "ranged"})
+    Debug.chat(originalSize, sizeChange)
+    return originalSize + sizeChange
+end
+
+function onInit()
+    getOriginalCreatureSize = ActorCommonManager.getCreatureSizeDnD3
+    ActorCommonManager.getCreatureSizeDnD3 = getCreatureSize
+end

--- a/scripts/size_change_attack.lua
+++ b/scripts/size_change_attack.lua
@@ -7,7 +7,7 @@ local function applySizeEffectsToAttackModRoll(rSource, rTarget, rRoll)
                 sizeChange = sizeChange + effect.mod
             end
             if sizeChange ~= 0 then
-                local sizeIndex = ActorCommonManager.getCreatureSizeDnD3(rSource)
+                local sizeIndex = SizeManager.getOriginalCreatureSize(rSource)
                 local effectBonus = math.abs(SizeChangeData.sizeCombatModifiers[sizeIndex] - SizeChangeData.sizeCombatModifiers[sizeIndex + sizeChange])
                 if sizeChange > 0 then
                     effectBonus = -effectBonus
@@ -43,7 +43,7 @@ local function applySizeEffectsToGrappleModRoll(rSource, rTarget, rRoll)
                 sizeChange = sizeChange + effect.mod
             end
             if sizeChange ~= 0 then
-                local sizeIndex = ActorCommonManager.getCreatureSizeDnD3(rSource)
+                local sizeIndex = SizeManager.getOriginalCreatureSize(rSource)
                 local effectBonus = systemSpecificGrappleBonus(sizeIndex, sizeChange)
                 rRoll.nMod = rRoll.nMod + effectBonus
                 local sMod = StringManager.convertDiceToString({}, effectBonus, true);

--- a/scripts/size_change_damage.lua
+++ b/scripts/size_change_damage.lua
@@ -76,7 +76,7 @@ local function applySizeEffectsToModRoll(rRoll, rSource, rTarget)
                     diceString = diceCount .. dice[1]
                 end
                 diceString = transformSpecialDice(diceString)
-                local sizeIndex = ActorCommonManager.getCreatureSizeDnD3(rSource)
+                local sizeIndex = SizeManager.getOriginalCreatureSize(rSource)
                 local progressionIndex = nil
                 for i = 1, math.abs(sizeChange), 1 do
                     if progressionIndex == nil then

--- a/scripts/size_change_defense.lua
+++ b/scripts/size_change_defense.lua
@@ -8,7 +8,7 @@ function getSizeEffectsBonusForDefender(rDefender, rRoll)
                 sizeChange = sizeChange + effect.mod
             end
             if sizeChange ~= 0 then
-                local sizeIndex = ActorCommonManager.getCreatureSizeDnD3(rDefender)
+                local sizeIndex = SizeManager.getOriginalCreatureSize(rDefender)
                 local effectBonus = math.abs(SizeChangeData.sizeCombatModifiers[sizeIndex] - SizeChangeData.sizeCombatModifiers[sizeIndex + sizeChange])
                 if isGrapple and sizeChange < 0 then
                     effectBonus = -effectBonus

--- a/scripts/size_change_skill.lua
+++ b/scripts/size_change_skill.lua
@@ -15,7 +15,7 @@ local function applySizeEffectsToModRoll(rSource, rTarget, rRoll)
                     sizeChange = sizeChange + effect.mod
                 end
                 if sizeChange ~= 0 then
-                    local sizeIndex = ActorCommonManager.getCreatureSizeDnD3(rSource)
+                    local sizeIndex = SizeManager.getOriginalCreatureSize(rSource)
                     local effectBonus = math.abs(SizeChangeData.sizeSkillModifiers[sizeIndex] - SizeChangeData.sizeSkillModifiers[sizeIndex + sizeChange])
                     if sizeChange > 0 then
                         effectBonus = -effectBonus

--- a/scripts/size_change_space.lua
+++ b/scripts/size_change_space.lua
@@ -8,7 +8,7 @@ end
 
 local function getTotalSize(rActor)
     local sizeChange = EffectManager35E.getEffectsBonus(rActor, "SIZE", true, {"melee", "ranged"})
-    return ActorCommonManager.getCreatureSizeDnD3(rActor) + sizeChange
+    return SizeManager.getOriginalCreatureSize(rActor) + sizeChange
 end
 
 local function getTotalReachBonus(rActor)
@@ -72,7 +72,7 @@ local function getReachFromSize(rActor, size)
         end
         return SizeChangeData.sizeTallReach[size] * reachMultiplier
     else -- Is NPC
-        local baseSize = ActorCommonManager.getCreatureSizeDnD3(rActor)
+        local baseSize = SizeManager.getOriginalCreatureSize(rActor)
         local nSpace, nReach = ActorCommonManager.getSpaceReach(nodeActor)
         if nSpace < nReach then -- Extra tall
             return SizeChangeData.sizeTallReach[size] * nReach / nSpace

--- a/scripts/size_change_space.lua
+++ b/scripts/size_change_space.lua
@@ -6,15 +6,6 @@ local function registerOptions()
             { labels = "option_val_space_only|option_val_space_and_reach", values="space|space_and_reach", baselabel = "option_val_off", baseval="off", default="off"})
 end
 
-local function getTotalSize(rActor)
-    local sizeChange = EffectManager35E.getEffectsBonus(rActor, "SIZE", true, {"melee", "ranged"})
-    return SizeManager.getOriginalCreatureSize(rActor) + sizeChange
-end
-
-local function getTotalReachBonus(rActor)
-    return EffectManager35E.getEffectsBonus(rActor, "REACH", true)
-end
-
 local function getStaticReachBonus(rActor)
     local reach = nil
     local effects, effectsCount = EffectManager35E.getEffectsBonusByType(rActor, "SREACH")
@@ -102,13 +93,13 @@ local function updateActorReach(rActor, size)
         DB.setValue(DB.findNode(rActor.sCTNode), "reach", "number", staticReach)
     else
         local sizeReach = getReachFromSize(rActor, size)
-        local reachBonus = getTotalReachBonus(rActor)
+        local reachBonus = EffectManager35E.getEffectsBonus(rActor, "REACH", true)
         DB.setValue(DB.findNode(rActor.sCTNode), "reach", "number", sizeReach + reachBonus)
     end
 end
 
 local function updateSpaceAndReach(rActor)
-    local size = getTotalSize(rActor)
+    local size = ActorCommonManager.getCreatureSizeDnD3(rActor)
     updateActorSpace(rActor, size)
     if OptionsManager.isOption(resizeOptionName, "space_and_reach") then
         updateActorReach(rActor, size)


### PR DESCRIPTION
When retrieving size, give the modified creature size. This allows conditionals to work properly.